### PR TITLE
fix: use proper CLI flags & EDT safety

### DIFF
--- a/src/main/kotlin/com/github/wass3r/intellijvelaplugin/services/VelaCliService.kt
+++ b/src/main/kotlin/com/github/wass3r/intellijvelaplugin/services/VelaCliService.kt
@@ -284,12 +284,12 @@ class VelaCliService(private val project: Project) {
                     // Add address and token from settings if they exist
                     if (settings.velaAddress.isNotBlank()) {
                         val validatedAddress = SecurityUtils.validateServerUrl(settings.velaAddress)
-                        add("--addr")
+                        add("--api.addr")
                         add(validatedAddress)
                     }
                     if (settings.velaToken.isNotBlank()) {
                         // Token is validated when retrieved from secure storage
-                        add("--api-token")
+                        add("--api.token")
                         add(settings.velaToken)
                     }
                 })

--- a/src/main/kotlin/com/github/wass3r/intellijvelaplugin/settings/VelaSettings.kt
+++ b/src/main/kotlin/com/github/wass3r/intellijvelaplugin/settings/VelaSettings.kt
@@ -51,7 +51,7 @@ class VelaSettings : PersistentStateComponent<VelaSettings> {
      */
     fun getVelaTokenSafely(): String {
         return if (com.intellij.openapi.application.ApplicationManager.getApplication().isDispatchThread) {
-            // Return empty string on EDT to avoid blocking
+            log.warn("getVelaTokenSafely() was called on the EDT. Returning an empty string to avoid blocking the UI thread.")
             ""
         } else {
             getVelaTokenInternal()

--- a/src/main/kotlin/com/github/wass3r/intellijvelaplugin/settings/VelaSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/wass3r/intellijvelaplugin/settings/VelaSettingsConfigurable.kt
@@ -95,7 +95,8 @@ class VelaSettingsConfigurable(project: Project) : SearchableConfigurable, Confi
     private fun loadInitialTokenValue() {
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                val token = settings.velaToken
+                // Use dedicated background thread method
+                val token = settings.getVelaTokenForBackground()
                 SwingUtilities.invokeLater {
                     initialToken = token
                     tokenLoadState = TokenLoadState.SUCCESS

--- a/src/test/kotlin/com/github/wass3r/intellijvelaplugin/services/VelaCliServiceTest.kt
+++ b/src/test/kotlin/com/github/wass3r/intellijvelaplugin/services/VelaCliServiceTest.kt
@@ -1,6 +1,7 @@
 package com.github.wass3r.intellijvelaplugin.services
 
 import com.github.wass3r.intellijvelaplugin.model.EnvironmentVariable
+import com.github.wass3r.intellijvelaplugin.settings.VelaSettings
 import com.intellij.testFramework.LightPlatformTestCase
 import java.io.File
 
@@ -11,15 +12,20 @@ import java.io.File
 class VelaCliServiceTest : LightPlatformTestCase() {
     
     private lateinit var velaService: VelaCliService
+    private lateinit var settings: VelaSettings
     
     override fun setUp() {
         super.setUp()
         velaService = VelaCliService.getInstance(project)
+        settings = VelaSettings.getInstance(project)
     }
     
     override fun tearDown() {
         try {
-            // Test-specific cleanup would go here
+            // Clean up test settings
+            settings.velaCliPath = "vela"
+            settings.velaAddress = ""
+            settings.velaToken = ""
         } catch (e: Exception) {
             addSuppressedException(e)
         } finally {
@@ -91,5 +97,145 @@ class VelaCliServiceTest : LightPlatformTestCase() {
         assertTrue("Should contain ENABLED_VAR", enabledVars.containsKey("ENABLED_VAR"))
         assertTrue("Should contain ANOTHER_ENABLED", enabledVars.containsKey("ANOTHER_ENABLED"))
         assertFalse("Should not contain DISABLED_VAR", enabledVars.containsKey("DISABLED_VAR"))
+    }
+    
+    fun testCliServiceWithServerConfiguration() {
+        // Test that the service can handle server configuration properly
+        val testAddress = "https://test.vela.server"
+        val testToken = "test-api-token-123"
+        
+        // Configure settings
+        settings.velaAddress = testAddress
+        settings.velaToken = testToken
+        
+        // Verify settings are applied
+        assertEquals("Server address should be set", testAddress, settings.velaAddress)
+        assertEquals("Token should be set", testToken, settings.velaToken)
+        
+        // Service should still be accessible
+        assertNotNull("Service should remain functional with settings", velaService)
+    }
+    
+    fun testCliServiceWithCustomCliPath() {
+        val customPath = "/custom/path/to/vela"
+        
+        // Configure custom CLI path
+        settings.velaCliPath = customPath
+        
+        // Verify setting is applied
+        assertEquals("Custom CLI path should be set", customPath, settings.velaCliPath)
+        
+        // Service should handle custom path
+        assertNotNull("Service should work with custom CLI path", velaService)
+    }
+    
+    fun testServiceConfigurationIntegration() {
+        // Test integration between service and settings
+        val testCliPath = "/usr/local/bin/vela"
+        val testAddress = "https://integration.test.vela"
+        val testToken = "integration-test-token"
+        
+        // Apply all settings
+        settings.velaCliPath = testCliPath
+        settings.velaAddress = testAddress
+        settings.velaToken = testToken
+        
+        // Verify all settings are properly configured
+        assertEquals("CLI path integration", testCliPath, settings.velaCliPath)
+        assertEquals("Server address integration", testAddress, settings.velaAddress)
+        assertEquals("Token integration", testToken, settings.velaToken)
+        
+        // Service should handle the configured state
+        assertNotNull("Service should handle full configuration", velaService)
+    }
+    
+    fun testCliFlagConstruction() {
+        // Test that CLI flags use the correct format (--api.addr and --api.token)
+        val testAddress = "https://test.vela.server"
+        val testToken = "test-token-123"
+        
+        // Configure settings with server and token
+        settings.velaAddress = testAddress
+        settings.velaToken = testToken
+        
+        // Use reflection to access the private buildCommandLine method for testing
+        val buildCommandLineMethod = VelaCliService::class.java.getDeclaredMethod(
+            "buildCommandLine", 
+            List::class.java
+        )
+        buildCommandLineMethod.isAccessible = true
+        
+        // Test command construction
+        val baseArgs = listOf("exec")
+        val commandLine = buildCommandLineMethod.invoke(velaService, baseArgs) as com.intellij.execution.configurations.GeneralCommandLine
+        
+        val parameters = commandLine.parametersList.parameters
+        
+        // Verify the correct flags are used
+        assertTrue("Should contain --api.addr flag", parameters.contains("--api.addr"))
+        assertTrue("Should contain --api.token flag", parameters.contains("--api.token"))
+        
+        // Verify the values are properly set
+        val addrIndex = parameters.indexOf("--api.addr")
+        val tokenIndex = parameters.indexOf("--api.token")
+        
+        assertTrue("--api.addr should have a value", addrIndex + 1 < parameters.size)
+        assertTrue("--api.token should have a value", tokenIndex + 1 < parameters.size)
+        
+        assertEquals("Server address should match", testAddress, parameters[addrIndex + 1])
+        assertEquals("Token should match", testToken, parameters[tokenIndex + 1])
+    }
+    
+    fun testCliFlagConstructionWithoutServerConfig() {
+        // Test CLI construction when no server configuration is provided
+        settings.velaAddress = ""
+        settings.velaToken = ""
+        
+        // Use reflection to test private method
+        val buildCommandLineMethod = VelaCliService::class.java.getDeclaredMethod(
+            "buildCommandLine", 
+            List::class.java
+        )
+        buildCommandLineMethod.isAccessible = true
+        
+        val baseArgs = listOf("exec")
+        val commandLine = buildCommandLineMethod.invoke(velaService, baseArgs) as com.intellij.execution.configurations.GeneralCommandLine
+        
+        val parameters = commandLine.parametersList.parameters
+        
+        // Should not contain server flags when not configured
+        assertFalse("Should not contain --api.addr when not configured", parameters.contains("--api.addr"))
+        assertFalse("Should not contain --api.token when not configured", parameters.contains("--api.token"))
+        
+        // Should only contain base arguments
+        assertEquals("Should contain only base arguments", baseArgs, parameters)
+    }
+    
+    fun testCliFlagConstructionPartialConfig() {
+        // Test CLI construction with only address configured (no token)
+        val testAddress = "https://partial.vela.server"
+        
+        settings.velaAddress = testAddress
+        settings.velaToken = ""
+        
+        // Use reflection to test private method
+        val buildCommandLineMethod = VelaCliService::class.java.getDeclaredMethod(
+            "buildCommandLine", 
+            List::class.java
+        )
+        buildCommandLineMethod.isAccessible = true
+        
+        val baseArgs = listOf("validate")
+        val commandLine = buildCommandLineMethod.invoke(velaService, baseArgs) as com.intellij.execution.configurations.GeneralCommandLine
+        
+        val parameters = commandLine.parametersList.parameters
+        
+        // Should contain address flag but not token flag
+        assertTrue("Should contain --api.addr flag", parameters.contains("--api.addr"))
+        assertFalse("Should not contain --api.token when not configured", parameters.contains("--api.token"))
+        
+        // Verify address value
+        val addrIndex = parameters.indexOf("--api.addr")
+        assertEquals("Server address should match", testAddress, parameters[addrIndex + 1])
     }
 }

--- a/src/test/kotlin/com/github/wass3r/intellijvelaplugin/settings/VelaSettingsConfigurableTest.kt
+++ b/src/test/kotlin/com/github/wass3r/intellijvelaplugin/settings/VelaSettingsConfigurableTest.kt
@@ -1,0 +1,151 @@
+package com.github.wass3r.intellijvelaplugin.settings
+
+import com.intellij.testFramework.LightPlatformTestCase
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+
+/**
+ * Tests for VelaSettingsConfigurable following IntelliJ Platform testing best practices.
+ * Tests the UI components and EDT safety features.
+ */
+class VelaSettingsConfigurableTest : LightPlatformTestCase() {
+    
+    private lateinit var configurable: VelaSettingsConfigurable
+    private lateinit var settings: VelaSettings
+    
+    override fun setUp() {
+        super.setUp()
+        settings = VelaSettings.getInstance(project)
+        configurable = VelaSettingsConfigurable(project)
+    }
+    
+    override fun tearDown() {
+        try {
+            // Clean up settings
+            settings.velaCliPath = "vela"
+            settings.velaAddress = ""
+            settings.velaToken = ""
+            
+            // Dispose configurable resources
+            configurable.disposeUIResources()
+        } catch (e: Exception) {
+            addSuppressedException(e)
+        } finally {
+            super.tearDown()
+        }
+    }
+    
+    fun testConfigurableCreation() {
+        assertNotNull("VelaSettingsConfigurable should be created", configurable)
+        assertEquals("Display name should be 'Vela'", "Vela", configurable.displayName)
+        assertNotNull("ID should be set", configurable.id)
+    }
+    
+    fun testUIComponentCreation() {
+        val component = configurable.createComponent()
+        assertNotNull("UI component should be created", component)
+    }
+    
+    fun testConfigurableId() {
+        val expectedId = "com.github.wass3r.intellijvelaplugin.settings.VelaSettingsConfigurable"
+        assertEquals("ID should match expected format", expectedId, configurable.id)
+    }
+    
+    fun testIsModifiedInitialState() {
+        // Create UI component to initialize fields
+        configurable.createComponent()
+        
+        // Wait for token loading to complete (background operation)
+        Thread.sleep(100)
+        
+        // Initially should not be modified
+        assertFalse("Should not be modified initially", configurable.isModified)
+    }
+    
+    fun testSettingsIntegration() {
+        val testCliPath = "/test/path/to/vela"
+        val testAddress = "https://test.vela.server"
+        val testToken = "test-token-123"
+        
+        // Set initial values in settings
+        settings.velaCliPath = testCliPath
+        settings.velaAddress = testAddress
+        settings.velaToken = testToken
+        
+        // Create component
+        val component = configurable.createComponent()
+        assertNotNull("Component should be created with settings", component)
+        
+        // Reset should reload values
+        configurable.reset()
+        
+        // Wait for background loading
+        Thread.sleep(100)
+        
+        // Values should be consistent
+        assertEquals("CLI path should match", testCliPath, settings.velaCliPath)
+        assertEquals("Address should match", testAddress, settings.velaAddress)
+    }
+    
+    fun testApplySettings() {
+        // Create UI component
+        configurable.createComponent()
+        
+        // Wait for initialization
+        Thread.sleep(100)
+        
+        // Verify apply doesn't throw exceptions
+        try {
+            configurable.apply()
+            // Test passes if no exception is thrown
+        } catch (e: Exception) {
+            fail("Apply should not throw exception: ${e.message}")
+        }
+    }
+    
+    fun testResourceDisposal() {
+        // Create component
+        configurable.createComponent()
+        
+        // Dispose resources
+        try {
+            configurable.disposeUIResources()
+            // Test passes if no exception is thrown
+        } catch (e: Exception) {
+            fail("Resource disposal should not throw exception: ${e.message}")
+        }
+    }
+    
+    fun testTokenLoadingStateHandling() {
+        val testToken = "async-test-token"
+        
+        // Set token in settings
+        settings.velaToken = testToken
+        
+        // Create component (which triggers async token loading)
+        val component = configurable.createComponent()
+        assertNotNull("Component should be created", component)
+        
+        // Wait for background token loading to complete
+        Thread.sleep(200)
+        
+        // Token should be loaded correctly (we can't directly access private fields,
+        // but we can verify the component was created successfully)
+        assertNotNull("Component should handle token loading", component)
+    }
+    
+    fun testEDTSafetyIntegration() {
+        // This test verifies that the configurable creates components without blocking
+        try {
+            // Create component (should not block)
+            val component = configurable.createComponent()
+            assertNotNull("Component should be created", component)
+            
+            // Test passes if we reach this point without timeout/blocking
+            assertTrue("Component creation should complete", true)
+        } catch (e: Exception) {
+            fail("Component creation should not throw exception: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
AI Generated Description Below:

This pull request introduces several improvements to the handling of Vela settings and the Vela CLI service, focusing on enhancing security, avoiding UI thread blocking, and improving user experience in the settings panel. The most important changes include updating CLI argument names, refactoring token management for thread safety, and improving the settings UI behavior.

### Updates to CLI argument handling:
* Updated CLI argument names in `VelaCliService` to align with the latest Vela CLI conventions (`--api.addr` and `--api.token` replaced `--addr` and `--api-token`).

### Improvements to token management:
* Refactored `velaToken` property in `VelaSettings` to delegate secure storage access to a new private method `getVelaTokenInternal`, while introducing a new public method `getVelaTokenSafely` to ensure UI thread safety. [[1]](diffhunk://#diff-a677ccea77b9a259e51036c6dc82aa22619dd080eb1e869ef307ae9ca0394992R26-R31) [[2]](diffhunk://#diff-a677ccea77b9a259e51036c6dc82aa22619dd080eb1e869ef307ae9ca0394992R48-R71)

### Enhancements to the settings UI:
* Introduced background loading of the initial API token value in `VelaSettingsConfigurable` to avoid blocking the Event Dispatch Thread (EDT) and updated the token field once the value is ready. [[1]](diffhunk://#diff-bee5409addec190316af818a723b3169bca3275fb9e99709f0c24c73d77cfc4cR39-R50) [[2]](diffhunk://#diff-bee5409addec190316af818a723b3169bca3275fb9e99709f0c24c73d77cfc4cL73-R120)
* Adjusted the `isModified` logic to compare the token field value with the loaded `initialToken` instead of directly accessing `settings.velaToken`.
* Updated the `reset` method to reload the token value asynchronously, ensuring the settings UI reflects the stored values correctly.