### PR TITLE
chore(deps): bump gradle to 9.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,7 +153,8 @@ intellijPlatform {
                 else productReleases
 
             reducedProductReleases.forEach { release ->
-                create("IC", release)
+                val versionStr = if (release.startsWith("IC-")) release.substring(3) else release
+                create("IC", versionStr)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,7 +151,10 @@ intellijPlatform {
             val reducedProductReleases =
                 if (productReleases.size > 2) listOf(productReleases.first(), productReleases.last())
                 else productReleases
-            ides(reducedProductReleases)
+
+            reducedProductReleases.forEach { release ->
+                create("IC", release)
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ platformPlugins =
 platformBundledPlugins =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.10.2
+gradleVersion = 9.0.0
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
AI Generated Description:

This pull request updates the Gradle version used in the project from 8.10.2 to 9.0.0. The changes ensure the project uses the latest Gradle release for improved features and compatibility.

### Gradle version update:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L23-R23): Updated the `gradleVersion` property from `8.10.2` to `9.0.0`.
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Updated the `distributionUrl` to point to the Gradle 9.0.0 binary distribution.